### PR TITLE
Fixed an issue when impute fails due to missing outlier data

### DIFF
--- a/R/analysisQuantifications.R
+++ b/R/analysisQuantifications.R
@@ -348,7 +348,13 @@ artmsAnalysisQuantifications <- function(log2fc_file,
     theImputedL2FC <- merge(dflog2fcinfinites,
                             imputedL2FCmelted,
                             by = c("Protein", "Label"),
-                            all.x = TRUE)
+                            all = FALSE)
+    # check size of theImputedL2FC compared with dflog2fcinfinites to see if we lost rows during imputation
+    # possibly we were unable to impute rows after removing outliers
+    if (nrow(theImputedL2FC) != nrow (dflog2fcinfinites)){
+      numMissing = nrow (dflog2fcinfinites) - nrow(theImputedL2FC)
+      message(" WARNING:  Failed to impute values for ", numMissing, "rows. Possibly due to outlier removal")
+    }
       
     theImputedL2FC$imputed <- "yes"
   }

--- a/R/enrichments.R
+++ b/R/enrichments.R
@@ -18,7 +18,7 @@
   
   listOfConditions <- unique(df$Comparisons)
   
-  complexEnrichmentConditions <- NULL
+  complexEnrichmentConditions <- data.frame()
   
   for (i in seq_len(length(listOfConditions))) {
     condi <- listOfConditions[i]


### PR DESCRIPTION
Hi David,

This actually deals with two issues we came across while processing the same data.  The first is that outlier removal removed data that was needed for imputation.  The imputation then failed which led to NA's in a table where they were causing problems.

The second issue is unrelated but it occurred on the same data during enrichment analysis. A return value of NULL was interacting poorly with a test of dimensions.  The fix was to have the default value be a data.frame with dimensions of 0,0.

I'll email you the data to reproduce it.