### PR TITLE
dont_check_names used for data.frame and data.table evidence_file

### DIFF
--- a/R/checkIfFile.R
+++ b/R/checkIfFile.R
@@ -16,23 +16,17 @@
                                is.evidence = FALSE) {
   # check if already a data.frame or data.table
   if (is.data.table(input_file)) {
-    x <- data.table(input_file)
+    x <- data.table(input_file, check.names = !dont_check_names)
   } else if (is.data.frame(input_file)) {
-    x <- data.frame(input_file)
+    x <- data.frame(input_file, check.names = !dont_check_names)
   } else if (is.vector(input_file)){
     if(length(input_file) == 1){
       if(!file.exists(input_file)){
         stop("The file ", input_file, " does not exist! ")
       }else{
-        if(dont_check_names){
-          x <- read.delim(input_file, 
-                          stringsAsFactors = FALSE)
-        }else{
-          x <- read.delim(input_file, 
-                          stringsAsFactors = FALSE,
-                          check.names = FALSE)
-        }
-        
+        read.delim(input_file,
+                   stringsAsFactors = FALSE,
+                   check.names = !dont_check_names)
       }
     }else{
       stop("The input object is not valid")

--- a/R/protein2SiteConversion.R
+++ b/R/protein2SiteConversion.R
@@ -133,7 +133,7 @@ then make the argument 'overwrite_evidence = TRUE'")
   ## map mod sites in data to index
   if(verbose) message("--- OPENING EVIDENCE FILE ")
   ## read in maxq. data
-  maxq_data <- .artms_checkIfFile(evidence_file, dont_check_names = FALSE)
+  maxq_data <- .artms_checkIfFile(evidence_file, dont_check_names = TRUE)
   maxq_data <- as.data.table(maxq_data)
   
   # Check maxquant version:


### PR DESCRIPTION
I discovered a problem in .artms_checkIfFile that was using dont_check_names the opposite that the name implies (beware double negative).  The only function to use this argument that I found (grep dont_check_names ./R/*) was protein2SiteConversion which was also using it opposite of the name, so no effective bug in usage.  However, there was a bug when a data.table or data.frame was passed in to protein2SiteConversion as the evidence file: no check.names argument was passed to data.frame() or data.table() so that names were always checked.     The function protein2SiteConversion uses names with spaces, e.g. "Leading proteins", so check.names should be FALSE in calls to read.delim(), data.table(), data.frame(). 

My changes are
1) check_names = !dont_check_names in arguments to read.delim, data.table, data.frame
2) dont_check_names = FALSE inside protein2SiteConversion
3) cleaning up redundant code in if(dont_check_names) statement