### PR TITLE
define mac.allsig etc. when enrich=FALSE

### DIFF
--- a/R/analysisQuantifications.R
+++ b/R/analysisQuantifications.R
@@ -1403,6 +1403,9 @@ artmsAnalysisQuantifications <- function(log2fc_file,
     }
   } else{
     if(verbose) message(">> NO ENRICHMENT of CHANGES (log2fc) SELECTED ")
+    mac.allsig <- NULL
+    mac.pos <- NULL
+    mac.neg <- NULL
   }
   # END enrichments
   #~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Crash at line number 1928 (was 1925) when these are not defined in case enrich=FALSE